### PR TITLE
Feature: Add delete task functionality

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -157,6 +157,7 @@
               <th>Title</th>
               <th>Status</th>
               <th>Created</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody id="rows"></tbody>
@@ -195,6 +196,19 @@
         return status === 'in-progress' ? 'in-progress' : status;
       }
 
+      async function deleteTask(id) {
+        setListMsg('Deleting…');
+        try {
+          const res = await fetch(`/api/tasks/${encodeURIComponent(id)}`, { method: 'DELETE' });
+          const body = await res.json().catch(() => ({}));
+          if (!res.ok) throw new Error(body.message || 'Delete failed');
+          setListMsg(body.message || 'Task deleted successfully.');
+          await loadTasks();
+        } catch (e) {
+          setListMsg(e.message || 'Delete failed', true);
+        }
+      }
+
       async function loadTasks() {
         setListMsg('Loading…');
         try {
@@ -213,7 +227,7 @@
         if (!tasks.length) {
           const tr = document.createElement('tr');
           const td = document.createElement('td');
-          td.colSpan = 3;
+          td.colSpan = 4;
           td.className = 'empty';
           td.textContent = 'No tasks yet. Add one above.';
           tr.appendChild(td);
@@ -266,9 +280,20 @@
           const tdCreated = document.createElement('td');
           tdCreated.textContent = formatDate(t.createdAt);
 
+          const tdActions = document.createElement('td');
+          const delBtn = document.createElement('button');
+          delBtn.type = 'button';
+          delBtn.className = 'secondary';
+          delBtn.setAttribute('aria-label', `Delete ${t.title}`);
+          delBtn.textContent = 'Delete';
+          delBtn.addEventListener('click', () => deleteTask(t.id));
+
+          tdActions.appendChild(delBtn);
+
           tr.appendChild(tdTitle);
           tr.appendChild(tdStatus);
           tr.appendChild(tdCreated);
+          tr.appendChild(tdActions);
           rowsEl.appendChild(tr);
         }
       }

--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -42,8 +42,26 @@ function patchTaskStatus(req, res) {
   return res.json(result.task);
 }
 
+function removeTask(req, res) {
+  const { id } = req.params;
+  const result = taskService.deleteTask(id);
+
+  if (!result.ok) {
+    if (result.code === 'NOT_FOUND') {
+      return res.status(404).json({ message: result.error });
+    }
+    return res.status(400).json({ message: result.error });
+  }
+
+  return res.json({
+    message: 'Task deleted successfully.',
+    task: result.task
+  });
+}
+
 module.exports = {
   listTasks,
   addTask,
-  patchTaskStatus
+  patchTaskStatus,
+  removeTask
 };

--- a/src/routes/tasks.js
+++ b/src/routes/tasks.js
@@ -6,5 +6,6 @@ const router = express.Router();
 router.get('/', taskController.listTasks);
 router.post('/', taskController.addTask);
 router.patch('/:id/status', taskController.patchTaskStatus);
+router.delete('/:id', taskController.removeTask);
 
 module.exports = router;

--- a/src/services/taskService.js
+++ b/src/services/taskService.js
@@ -61,6 +61,15 @@ function updateTaskStatus(id, status) {
   return { ok: true, task };
 }
 
+function deleteTask(id) {
+  const idx = tasks.findIndex((t) => t.id === String(id));
+  if (idx === -1) {
+    return { ok: false, code: 'NOT_FOUND', error: 'Task not found.' };
+  }
+  const [deletedTask] = tasks.splice(idx, 1);
+  return { ok: true, task: deletedTask };
+}
+
 /**
  * Reset store to seed data (used by tests for isolation).
  */
@@ -72,6 +81,7 @@ module.exports = {
   getAllTasks,
   createTask,
   updateTaskStatus,
+  deleteTask,
   resetTasks,
   ALLOWED_STATUSES
 };

--- a/tests/task.test.js
+++ b/tests/task.test.js
@@ -58,4 +58,19 @@ describe('devops-task-tracker API', () => {
     expect(res.status).toBe(400);
     expect(res.body).toHaveProperty('message');
   });
+
+  test('DELETE /api/tasks/:id deletes a task', async () => {
+    const title = `To delete ${Date.now()}`;
+    const createRes = await request(app).post('/api/tasks').send({ title });
+    expect(createRes.status).toBe(201);
+    const taskId = createRes.body.task.id;
+
+    const delRes = await request(app).delete(`/api/tasks/${taskId}`);
+    expect(delRes.status).toBe(200);
+    expect(delRes.body).toMatchObject({
+      message: 'Task deleted successfully.',
+      task: { id: taskId, title }
+    });
+    expect(delRes.body.task).toHaveProperty('createdAt');
+  });
 });


### PR DESCRIPTION
This PR adds task deletion support to the application.

Changes:
- Added DELETE /api/tasks/:id endpoint
- Added delete task controller and service logic
- Added delete button to the UI
- Added test coverage for task deletion

Fixes #2